### PR TITLE
Link DOIs to preferred resolver

### DIFF
--- a/doc/Bibliography.bib
+++ b/doc/Bibliography.bib
@@ -32,7 +32,7 @@ journal = {Bioinformatics}
   biburl = {http://www.bibsonomy.org/bibtex/29d15841bebf7cc2724776b53f0eb58a8/dblp},
   booktitle = {IJCNN},
   crossref = {conf/ijcnn/2011},
-  ee = {http://dx.doi.org/10.1109/IJCNN.2011.6033446},
+  ee = {https://doi.org/10.1109/IJCNN.2011.6033446},
   interhash = {50c12d417ff1934fb6a2388a2bb6d43c},
   intrahash = {9d15841bebf7cc2724776b53f0eb58a8},
   isbn = {978-1-4244-9635-8},
@@ -50,7 +50,7 @@ journal = {Bioinformatics}
     abstract = {{Motivation: Small-induced subgraphs called graphlets are emerging as a possible tool for exploration of global and local structure of networks and for analysis of roles of individual nodes. One of the obstacles to their wider use is the computational complexity of algorithms for their discovery and counting.}},
     author = {Ho\v{c}evar, Toma\v{z} and Dem\v{s}ar, Janez},
     citeulike-article-id = {12924733},
-    citeulike-linkout-0 = {http://dx.doi.org/10.1093/bioinformatics/btt717},
+    citeulike-linkout-0 = {https://doi.org/10.1093/bioinformatics/btt717},
     citeulike-linkout-1 = {http://bioinformatics.oxfordjournals.org/content/early/2013/12/11/bioinformatics.btt717.abstract},
     citeulike-linkout-2 = {http://bioinformatics.oxfordjournals.org/content/early/2013/12/11/bioinformatics.btt717.full.pdf},
     citeulike-linkout-3 = {http://bioinformatics.oxfordjournals.org/cgi/content/abstract/30/4/559},
@@ -69,7 +69,7 @@ journal = {Bioinformatics}
     priority = {2},
     publisher = {Oxford University Press},
     title = {{A combinatorial approach to graphlet counting}},
-    url = {http://dx.doi.org/10.1093/bioinformatics/btt717},
+    url = {https://doi.org/10.1093/bioinformatics/btt717},
     volume = {30},
     year = {2014}
 }
@@ -86,7 +86,7 @@ journal = {Bioinformatics}
   volume    = {7},
   number    = {3},
   year      = {2010},
-  url       = {http://dx.doi.org/10.2390/biecoll-jib-2010-135},
+  url       = {https://doi.org/10.2390/biecoll-jib-2010-135},
   doi       = {10.2390/biecoll-jib-2010-135},
   timestamp = {Tue, 13 Apr 2010 08:46:34 +0200},
   biburl    = {http://dblp.uni-trier.de/rec/bib/journals/jib/MemisevicMP10a},
@@ -98,7 +98,7 @@ journal = {Bioinformatics}
   author = {Camacho, Christiam and Coulouris, George and Avagyan, Vahram and Ma, Ning and Papadopoulos, Jason S. and Bealer, Kevin and Madden, Thomas L.},
   biburl = {http://www.bibsonomy.org/bibtex/2c804e89f76584cfaa6afe37fc3ae1431/dblp},
   date = {2010-07-01},
-  ee = {http://dx.doi.org/10.1186/1471-2105-10-421},
+  ee = {https://doi.org/10.1186/1471-2105-10-421},
   interhash = {5976e131d297952c72542177ae0bccfd},
   intrahash = {c804e89f76584cfaa6afe37fc3ae1431},
   journal = {BMC Bioinformatics},
@@ -120,7 +120,7 @@ pages = "207 - 217",
 year = "1998",
 note = "",
 issn = "0305-0548",
-doi = "http://dx.doi.org/10.1016/S0305-0548(97)00054-3",
+doi = "https://doi.org/10.1016/S0305-0548(97)00054-3",
 url = "http://www.sciencedirect.com/science/article/pii/S0305054897000543",
 author = "Moon-Won Park and Yeong-Dae Kim"
 }
@@ -142,7 +142,7 @@ author = "Moon-Won Park and Yeong-Dae Kim"
     priority = {2},
     publisher = {Oxford University Press},
     title = {{NetCoffee: a fast and accurate global alignment approach to identify functionally conserved proteins in multiple networks}},
-    url = {http://dx.doi.org/10.1093/bioinformatics/btt715},
+    url = {https://doi.org/10.1093/bioinformatics/btt715},
     volume = {30},
     year = {2014}
 }
@@ -166,7 +166,7 @@ author = "Moon-Won Park and Yeong-Dae Kim"
     priority = {2},
     publisher = {Nature Publishing Group},
     title = {{Gene Ontology: tool for the unification of biology}},
-    url = {http://dx.doi.org/10.1038/75556},
+    url = {https://doi.org/10.1038/75556},
     volume = {25},
     year = {2000}
 }
@@ -180,7 +180,7 @@ volume={45},
 number={1},
 doi={10.1007/BF00940812},
 title={Thermodynamical approach to the traveling salesman problem: An efficient simulation algorithm},
-url={http://dx.doi.org/10.1007/BF00940812},
+url={https://doi.org/10.1007/BF00940812},
 publisher={Kluwer Academic Publishers-Plenum Publishers},
 keywords={Traveling salesman problem; Monte Carlo optimization; importance sampling},
 author={\v{C}ern\'{y}, V.},
@@ -279,7 +279,7 @@ issue  ="7",
 pages  ="734-743",
 publisher  ="The Royal Society of Chemistry",
 doi  ="10.1039/C2IB00140C",
-url  ="http://dx.doi.org/10.1039/C2IB00140C",
+url  ="https://doi.org/10.1039/C2IB00140C",
 abstract  ="Networks are an invaluable framework for modeling biological systems. Analyzing protein-protein interaction (PPI) networks can provide insight into underlying cellular processes. It is expected that comparison and alignment of biological networks will have a similar impact on our understanding of evolution{,} biological function{,} and disease as did sequence comparison and alignment. Here{,} we introduce a novel pairwise global alignment algorithm called Common-neighbors based GRAph ALigner (C-GRAAL) that uses heuristics for maximizing the number of aligned edges between two networks and is based solely on network topology. As such{,} it can be applied to any type of network{,} such as social{,} transportation{,} or electrical networks. We apply C-GRAAL to align PPI networks of eukaryotic and prokaryotic species{,} as well as inter-species PPI networks{,} and we demonstrate that the resulting alignments expose large connected and functionally topologically aligned regions. We use the resulting alignments to transfer biological knowledge across species{,} successfully validating many of the predictions. Moreover{,} we show that C-GRAAL can be used to align human-pathogen inter-species PPI networks and that it can identify patterns of pathogen interactions with host proteins solely from network topology."
 }
 
@@ -317,7 +317,7 @@ HubAlign
     priority = {2},
     publisher = {Oxford University Press},
     title = {{HubAlign: an accurate and efficient method for global alignment of protein–protein interaction networks}},
-    url = {http://dx.doi.org/10.1093/bioinformatics/btu450},
+    url = {https://doi.org/10.1093/bioinformatics/btu450},
     volume = {30},
     year = {2014}
 }
@@ -381,7 +381,7 @@ doi = {bioinformatics/btr127},
 journal = {BIOINFORMATICS},
 pages = {1390--1396},
 title = {Integrative network alignment reveals large regions of global network similarity in yeast and human},
-url = {http://dx.doi.org/10.1093/bioinformatics/btr127},
+url = {https://doi.org/10.1093/bioinformatics/btr127},
 volume = {27},
 year = {2011}
 }
@@ -403,7 +403,7 @@ IsoRankN
   added-at = {2011-09-29T00:00:00.000+0200},
   author = {Liao, Chung-Shou and Lu, Kanghao and Baym, Michael and Singh, Rohit and Berger, Bonnie},
   biburl = {http://www.bibsonomy.org/bibtex/2f268679322a7fbf083c29f2fa59dc628/dblp},
-  ee = {http://dx.doi.org/10.1093/bioinformatics/btp203},
+  ee = {https://doi.org/10.1093/bioinformatics/btp203},
   interhash = {0b2b9492474d0488fc2e28d00b684fb0},
   intrahash = {f268679322a7fbf083c29f2fa59dc628},
   journal = {Bioinformatics},
@@ -428,7 +428,7 @@ series={Lecture Notes in Computer Science},
 editor={Pop, Mihai and Touzet, Hélène},
 doi={10.1007/978-3-662-48221-6_2},
 title={Simultaneous Optimization of both Node and Edge Conservation in Network Alignment via WAVE},
-url={http://dx.doi.org/10.1007/978-3-662-48221-6_2},
+url={https://doi.org/10.1007/978-3-662-48221-6_2},
 publisher={Springer Berlin Heidelberg},
 author={Sun, Yihan and Crawford, Joseph and Tang, Jie and Milenković, Tijana},
 pages={16-39},
@@ -510,7 +510,7 @@ journal = {Bioinformatics}
  pages = {23:23--23:32},
  articleno = {23},
  numpages = {10},
- url = {http://doi.acm.org/10.1145/2506583.2508968},
+ url = {https://doi.acm.org/10.1145/2506583.2508968},
  doi = {10.1145/2506583.2508968},
  acmid = {2508968},
  publisher = {ACM},
@@ -631,7 +631,7 @@ ontology matching
   number    = {8},
   pages     = {1218--1232},
   year      = {2009},
-  url       = {http://dx.doi.org/10.1109/TKDE.2008.202},
+  url       = {https://doi.org/10.1109/TKDE.2008.202},
   doi       = {10.1109/TKDE.2008.202},
   timestamp = {Wed, 17 Apr 4439985 12:14:24 +},
   biburl    = {http://dblp.uni-trier.de/rec/bib/journals/tkde/LiTLL09},
@@ -651,7 +651,7 @@ ontology matching
  issn = {0162-8828},
  pages = {2227--2242},
  numpages = {16},
- url = {http://dx.doi.org/10.1109/TPAMI.2008.245},
+ url = {https://doi.org/10.1109/TPAMI.2008.245},
  doi = {10.1109/TPAMI.2008.245},
  acmid = {1639283},
  publisher = {IEEE Computer Society},
@@ -715,7 +715,7 @@ graph isomorphism np-complete
  location = {Shaker Heights, Ohio, USA},
  pages = {151--158},
  numpages = {8},
- url = {http://doi.acm.org/10.1145/800157.805047},
+ url = {https://doi.acm.org/10.1145/800157.805047},
  doi = {10.1145/800157.805047},
  acmid = {805047},
  publisher = {ACM},
@@ -808,7 +808,7 @@ volume = {72},
 number = {3},
 publisher = {Wiley Subscription Services, Inc., A Wiley Company},
 issn = {1097-0134},
-url = {http://dx.doi.org/10.1002/prot.21989},
+url = {https://doi.org/10.1002/prot.21989},
 doi = {10.1002/prot.21989},
 pages = {1030--1037},
 keywords = {gene prioritization, gene–disease associations, protein–disease associations, protein function prediction},
@@ -827,11 +827,11 @@ year = {1989},
 doi = {10.1287/ijoc.1.3.190},
 
 URL = { 
-        http://dx.doi.org/10.1287/ijoc.1.3.190
+        https://doi.org/10.1287/ijoc.1.3.190
     
 },
 eprint = { 
-        http://dx.doi.org/10.1287/ijoc.1.3.190
+        https://doi.org/10.1287/ijoc.1.3.190
     
 }
 
@@ -854,11 +854,11 @@ year = {1990},
 doi = {10.1287/ijoc.2.1.4},
 
 URL = { 
-        http://dx.doi.org/10.1287/ijoc.2.1.4
+        https://doi.org/10.1287/ijoc.2.1.4
     
 },
 eprint = { 
-        http://dx.doi.org/10.1287/ijoc.2.1.4
+        https://doi.org/10.1287/ijoc.2.1.4
     
 }
 

--- a/wrappedAlgorithms/PISWAP/networkx/algorithms/centrality/current_flow_closeness.py
+++ b/wrappedAlgorithms/PISWAP/networkx/algorithms/centrality/current_flow_closeness.py
@@ -68,7 +68,7 @@ def current_flow_closeness_centrality(G, normalized=True, weight='weight',
     .. [2] Stephenson, K. and Zelen, M.
        Rethinking centrality: Methods and examples.
        Social Networks. Volume 11, Issue 1, March 1989, pp. 1-37
-       http://dx.doi.org/10.1016/0378-8733(89)90016-6
+       https://doi.org/10.1016/0378-8733(89)90016-6
     """
     from networkx.utils import reverse_cuthill_mckee_ordering 
     try:

--- a/wrappedAlgorithms/PISWAP/networkx/algorithms/clique.py
+++ b/wrappedAlgorithms/PISWAP/networkx/algorithms/clique.py
@@ -76,13 +76,13 @@ def find_cliques(G):
        Computing and Combinatorics,
        10th Annual International Conference on
        Computing and Combinatorics (COCOON 2004), 25 October 2006, Pages 28-42
-       http://dx.doi.org/10.1016/j.tcs.2006.06.015
+       https://doi.org/10.1016/j.tcs.2006.06.015
 
     .. [3] F. Cazals, C. Karande,
        A note on the problem of reporting maximal cliques,
        Theoretical Computer Science,
        Volume 407, Issues 1-3, 6 November 2008, Pages 564-568,
-       http://dx.doi.org/10.1016/j.tcs.2008.05.010
+       https://doi.org/10.1016/j.tcs.2008.05.010
     """
     # Cache nbrs and find first pivot (highest degree)
     maxconn=-1
@@ -210,13 +210,13 @@ def find_cliques_recursive(G):
        Computing and Combinatorics,
        10th Annual International Conference on
        Computing and Combinatorics (COCOON 2004), 25 October 2006, Pages 28-42
-       http://dx.doi.org/10.1016/j.tcs.2006.06.015
+       https://doi.org/10.1016/j.tcs.2006.06.015
 
     .. [3] F. Cazals, C. Karande,
        A note on the problem of reporting maximal cliques,
        Theoretical Computer Science,
        Volume 407, Issues 1-3, 6 November 2008, Pages 564-568,
-       http://dx.doi.org/10.1016/j.tcs.2008.05.010
+       https://doi.org/10.1016/j.tcs.2008.05.010
     """
     nnbrs={}
     for n,nbrs in G.adjacency_iter():

--- a/wrappedAlgorithms/PISWAP/networkx/algorithms/cycles.py
+++ b/wrappedAlgorithms/PISWAP/networkx/algorithms/cycles.py
@@ -142,7 +142,7 @@ def simple_cycles(G):
     ----------
     .. [1] Finding all the elementary circuits of a directed graph.
        D. B. Johnson, SIAM Journal on Computing 4, no. 1, 77-84, 1975. 
-       http://dx.doi.org/10.1137/0204007
+       https://doi.org/10.1137/0204007
 
     See Also
     --------

--- a/wrappedAlgorithms/PISWAP/networkx/generators/bipartite.py
+++ b/wrappedAlgorithms/PISWAP/networkx/generators/bipartite.py
@@ -339,7 +339,7 @@ def bipartite_preferential_attachment_graph(aseq,p,create_using=None,seed=None):
     .. [1] Jean-Loup Guillaume and Matthieu Latapy,
        Bipartite structure of all complex networks,
        Inf. Process. Lett. 90, 2004, pg. 215-221
-       http://dx.doi.org/10.1016/j.ipl.2004.03.007
+       https://doi.org/10.1016/j.ipl.2004.03.007
     """
     if create_using is None:
         create_using=networkx.MultiGraph()

--- a/wrappedAlgorithms/PISWAP/networkx/generators/random_graphs.py
+++ b/wrappedAlgorithms/PISWAP/networkx/generators/random_graphs.py
@@ -318,7 +318,7 @@ def newman_watts_strogatz_graph(n, k, p, seed=None):
     .. [1] M. E. J. Newman and D. J. Watts,
        Renormalization group analysis of the small-world network model,
        Physics Letters A, 263, 341, 1999.
-       http://dx.doi.org/10.1016/S0375-9601(99)00757-4
+       https://doi.org/10.1016/S0375-9601(99)00757-4
     """
     if seed is not None:
         random.seed(seed)

--- a/wrappedAlgorithms/PISWAP/networkx/utils/rcm.py
+++ b/wrappedAlgorithms/PISWAP/networkx/utils/rcm.py
@@ -51,7 +51,7 @@ def cuthill_mckee_ordering(G, start=None):
     .. [1] E. Cuthill and J. McKee.
        Reducing the bandwidth of sparse symmetric matrices,
        In Proc. 24th Nat. Conf. ACM, pages 157-172, 1969.
-       http://doi.acm.org/10.1145/800195.805928
+       https://doi.acm.org/10.1145/800195.805928
     .. [2]  Steven S. Skiena. 1997. The Algorithm Design Manual. 
        Springer-Verlag New York, Inc., New York, NY, USA.
     """
@@ -100,7 +100,7 @@ def reverse_cuthill_mckee_ordering(G, start=None):
     .. [1] E. Cuthill and J. McKee.
        Reducing the bandwidth of sparse symmetric matrices,
        In Proc. 24th Nat. Conf. ACM, pages 157-72, 1969.
-       http://doi.acm.org/10.1145/800195.805928
+       https://doi.acm.org/10.1145/800195.805928
     .. [2]  Steven S. Skiena. 1997. The Algorithm Design Manual. 
        Springer-Verlag New York, Inc., New York, NY, USA.
     """


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Here's a suggestion to implement that by updating static DOI links, including them one from `acm.org`, because they support `https` as well.

Cheers!